### PR TITLE
Update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# [Cross-Team Collaboration Fun Times](https://rust-ctcft.github.io/ctcft/)
+# [Cross-Team Collaboration Fun Times](https://rust-lang.github.io/ctcft/)
 
-[![camprust](https://raw.githubusercontent.com/rust-ctcft/ctcft/main/img/camprust.png)](https://rust-ctcft.github.io/ctcft/)
+[![camprust](https://raw.githubusercontent.com/rust-lang/ctcft/main/img/camprust.png)](https://rust-lang.github.io/ctcft/)

--- a/book.toml
+++ b/book.toml
@@ -7,7 +7,7 @@ title = "Cross-Team Collaboration Fun Times"
 
 [output.html]
 site-url = "/ctcft/"
-git-repository-url = "https://github.com/rust-ctcft/ctcft"
+git-repository-url = "https://github.com/rust-lang/ctcft"
 
 [output.html.fold]
 enable = true

--- a/src/faq.md
+++ b/src/faq.md
@@ -24,7 +24,7 @@ We're looking for three kinds of things:
 
 ### How can I propose an agenda item?
 
-[Open an issue on the CTCFT repo to let nikomatsakis know about it!](https://github.com/rust-ctcft/ctcft/issues/new/choose)
+[Open an issue on the CTCFT repo to let nikomatsakis know about it!](https://github.com/rust-lang/ctcft/issues/new/choose)
 
 ### What if I have something sensitive to discuss?
 

--- a/src/internets.md
+++ b/src/internets.md
@@ -5,7 +5,7 @@
 Here are links to various Rust CTCFT related internet things:
 
 * [@RustCTCFT on Twitter!](https://twitter.com/rustctcft)
-* [rust-ctcft/ctcft on Github](https://github.com/rust-ctcft/ctcft/)
+* [rust-lang/ctcft on Github](https://github.com/rust-lang/ctcft/)
 * [RustCTCFT Calendar](https://calendar.google.com/calendar/embed?src=7n0vvoqfe0kbnk6i04uiu52t30%40group.calendar.google.com&ctz=America%2FNew_York)
 
 

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -2,7 +2,7 @@
 
 ## Fostering cross-team collaboration in the Rust project
 
-![Logo](https://raw.githubusercontent.com/rust-ctcft/ctcft/main/img/camprust.png)
+![Logo](https://raw.githubusercontent.com/rust-lang/ctcft/main/img/camprust.png)
 
 ## What is this meeting about?
 


### PR DESCRIPTION
This PR updates the links on the README to point to `rust-lang/ctcft`