### PR TITLE
Preparing February agenda

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: Deploy mdBook
-on: [push]
+
+on:
+  push:
+    branches:
+      - main
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [👋🏽 Welcome](./welcome.md)
 - [👨‍👩‍👧 Meetings](./meetings.md)
+    - [2022-02-21](./meetings/2022-02-21.md)
     - [2022-01-17](./meetings/2022-01-17.md)
     - [2021-11-22](./meetings/2021-11-22.md)
     - [2021-10-18](./meetings/2021-10-18.md)

--- a/src/meetings/2022-02-21.md
+++ b/src/meetings/2022-02-21.md
@@ -19,14 +19,14 @@ Working Group and the Compiler Team.
 
 - (5 min) Opening remarks 👋 ([angelonfira])
 - (20 min) Rust 2021 Survey Results ([nrc])
-- (20 min) Async working group update ([tmandry])
+  - Nick will summarise the results of the survey, highlight findings which
+    might be of interest to Rust teams, and outline how teams can request more
+    in-depth analysis.
 - (20 min) Compiler team ambitions ([pnkfelix], [wesleywiser])
 - (5 min) Closing ([angelonfira])
 
-[nikomatsakis]: https://github.com/nikomatsakis
 [angelonfira]: https://github.com/angelonfira
 [nrc]: https://github.com/nrc
-[tmandry]: https://github.com/tmandry
 [pnkfelix]: https://github.com/pnkfelix
 [wesleywiser]: https://github.com/wesleywiser
 

--- a/src/meetings/2022-02-21.md
+++ b/src/meetings/2022-02-21.md
@@ -8,22 +8,27 @@
 | Recording                                      | (link posted after call) |
 
 [see in your time zone]: https://everytimezone.com/s/820f8d47
-[cal]: TODO
-[calsh]: TODO
+[cal]: https://calendar.google.com/event?action=TEMPLATE&tmeid=Nm02YW04bm1lbG5mcDMxYzNwMmEyNGxrcGQgN24wdnZvcWZlMGtibms2aTA0dWl1NTJ0MzBAZw&tmsrc=7n0vvoqfe0kbnk6i04uiu52t30%40group.calendar.google.com
+[calsh]: https://calendar.google.com/event?action=TEMPLATE&tmeid=MWEzM2pibGdwdTV0ajhodmRlc2FtbzMzZXYgN24wdnZvcWZlMGtibms2aTA0dWl1NTJ0MzBAZw&tmsrc=7n0vvoqfe0kbnk6i04uiu52t30%40group.calendar.google.com
 
 ## Agenda
 
-For this CTCFT meeting, the theme is "roadmap-like".
+For this month's CTCFT meeting, the theme is "planning for 2022". We'll hear
+about the results of the 2021 Rust survey, and updates happening in the Async
+Working Group and the Compiler Team.
 
 - (5 min) Opening remarks 👋 ([angelonfira])
-- (n min) Results of the Rust Survey (to confirm)
-- (n min) What people need from Rust (to confirm)
-- (n min) Rust Skill Trees (to confirm)
-- (n min) Async working group update (to confirm)
-- (n min) Debugger thoughts (to confirm)
-- (n min) Initiative process (to confirm)
+- (20 min) Rust 2021 Survey Results ([nrc])
+- (20 min) Async working group update ([tmandry])
+- (20 min) Compiler team ambitions ([pnkfelix], [wesleywiser])
+- (5 min) Closing ([angelonfira])
 
+[nikomatsakis]: https://github.com/nikomatsakis
 [angelonfira]: https://github.com/angelonfira
+[nrc]: https://github.com/nrc
+[tmandry]: https://github.com/tmandry
+[pnkfelix]: https://github.com/pnkfelix
+[wesleywiser]: https://github.com/wesleywiser
 
 ## Social hour
 

--- a/src/meetings/2022-02-21.md
+++ b/src/meetings/2022-02-21.md
@@ -1,0 +1,34 @@
+# 2021-02-21
+
+| Info                                           |                          |
+| ---------------------------------------------- | ------------------------ |
+| Time                                           | [See in your time zone]  |
+| Calendar event (with Zoom details)             | [link][cal]              |
+| Social hour calendar event (with Zoom details) | [link][calsh]            |
+| Recording                                      | (link posted after call) |
+
+[see in your time zone]: https://everytimezone.com/s/820f8d47
+[cal]: TODO
+[calsh]: TODO
+
+## Agenda
+
+For this CTCFT meeting, the theme is "roadmap-like".
+
+- (5 min) Opening remarks 👋 ([angelonfira])
+- (n min) Results of the Rust Survey (to confirm)
+- (n min) What people need from Rust (to confirm)
+- (n min) Rust Skill Trees (to confirm)
+- (n min) Async working group update (to confirm)
+- (n min) Debugger thoughts (to confirm)
+- (n min) Initiative process (to confirm)
+
+[angelonfira]: https://github.com/angelonfira
+
+## Social hour
+
+Like always, we'll be running a social hour after the CTCFT. The idea is really
+simple: for the hour after the meeting, we will create breakout rooms in Zoom
+with different themes. You can join any breakout room you like and hangout.
+
+[ctcft calendar]: https://calendar.google.com/calendar/embed?src=7n0vvoqfe0kbnk6i04uiu52t30%40group.calendar.google.com


### PR DESCRIPTION
Preparing the February CTCFT agenda :slightly_smiling_face: 

So far, the schedule looks like this:

- (5 min) Opening remarks
- (20 min) Rust 2021 Survey Results #13 (@nrc) :heavy_check_mark: 
- (20 min) Async working group update #15 (@tmandry) :question: 
- (20 min) Compiler team ambitions #23 (@pnkfelix, @wesleywiser) :heavy_check_mark: 
