### PR TITLE
Update talk proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/talk-proposal.md
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.md
@@ -11,7 +11,7 @@ assignees: ''
 
 **General idea:** *What is the general idea of what you want to present? A brief paragraph is good.*
 
-**Theme**: *Which [currently suggested theme] could your talk fall under and how does it relate to that theme? You may select multiple potential themes.*
+**Theme**: *Which [currently suggested theme] could your talk fall under and how does it relate to that theme? You may select multiple potential themes. If you're not sure, or it doesn't fit any theme, that's ok too.*
 
 **Which of the following categories apply:** (You can pick more than one!)
 

--- a/.github/ISSUE_TEMPLATE/talk-proposal.md
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.md
@@ -1,8 +1,8 @@
 ---
-name: Agenda item suggestion
-about: Suggest an idea for a future meeting agenda
+name: Talk Proposal
+about: Suggest a talk for a future meeting agenda
 title: ''
-labels: suggested agenda item
+labels: talk proposal
 assignees: ''
 
 ---
@@ -10,6 +10,8 @@ assignees: ''
 **Who:** *List github user names for folks who would present the item*
 
 **General idea:** *What is the general idea of what you want to present? A brief paragraph is good.*
+
+**Theme**: *Which [currently suggested theme] could your talk fall under and how does it relate to that theme? You may select multiple potential themes.*
 
 **Which of the following categories apply:** (You can pick more than one!)
 
@@ -21,4 +23,4 @@ assignees: ''
 
 **What kind of feedback are you looking for from the audience (if any)? Are there specific questions you'd like to ask?**
 
-
+[currently suggested theme]: https://github.com/rust-lang/ctcft/issues?q=is%3Aissue+is%3Aopen+label%3A%22suggested+theme%22


### PR DESCRIPTION
Renamed the template to be about talk proposals instead of agenda items and added a section about how it relates existing suggested themes.

I'm wondering if it might also be a good idea to include an expected duration for the talk.